### PR TITLE
Add Laravel Standard README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Laravel Standard
+
+This repository defines the **Laravel Standard**—our shared conventions for building applications with Laravel, Vue 3, and Inertia.js. Consistent structure and coding practices make projects easier to maintain and ensure developers and agents can collaborate effectively.
+
+## Guides
+
+Read the following documents for detailed conventions:
+
+- [Laravel Guide](./laravel-guide.md) – backend architecture and coding standards.
+- [Vue Guide](./vue-guide.md) – frontend patterns for Vue 3 and Inertia.js.
+
+All developers and agents are expected to follow these guides when working on Laravel projects.


### PR DESCRIPTION
## Summary
- add root README defining the Laravel Standard and the role of Laravel, Vue, and Inertia
- link to the existing Laravel and Vue guides for detailed coding conventions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68acbcf94ca483258962baaa740845d4